### PR TITLE
🌿 make fernignored classes pydantic v1 and v2 compatible

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -33,3 +33,5 @@ src/vocode/types/end_conversation_action_params.py
 src/vocode/types/transfer_call_action_params.py
 src/vocode/types/add_to_conference_action_params.py
 src/vocode/types/set_hold_action_params.py
+
+tests/test_client.py

--- a/src/vocode/types/add_to_conference_action_params.py
+++ b/src/vocode/types/add_to_conference_action_params.py
@@ -4,11 +4,14 @@ import datetime as dt
 import typing
 import typing_extensions
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
 from .add_to_conference_action_params_action_trigger import AddToConferenceActionParamsActionTrigger
 from .add_to_conference_config import AddToConferenceConfig
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class AddToConferenceActionParams(pydantic.BaseModel):

--- a/src/vocode/types/add_to_conference_action_update_params.py
+++ b/src/vocode/types/add_to_conference_action_update_params.py
@@ -3,12 +3,15 @@
 import datetime as dt
 import typing
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
 from .add_to_conference_action_update_params_action_trigger import AddToConferenceActionUpdateParamsActionTrigger
 from .add_to_conference_action_update_params_config import AddToConferenceActionUpdateParamsConfig
 import typing_extensions
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class AddToConferenceActionUpdateParams(pydantic.BaseModel):

--- a/src/vocode/types/azure_voice_params.py
+++ b/src/vocode/types/azure_voice_params.py
@@ -4,9 +4,12 @@ import datetime as dt
 import typing
 import typing_extensions
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class AzureVoiceParams(pydantic.BaseModel):

--- a/src/vocode/types/azure_voice_update_params.py
+++ b/src/vocode/types/azure_voice_update_params.py
@@ -3,14 +3,17 @@
 import datetime as dt
 import typing
 
-import pydantic
-
 import typing_extensions
 
 from ..core.datetime_utils import serialize_datetime
 from .azure_voice_update_params_pitch import AzureVoiceUpdateParamsPitch
 from .azure_voice_update_params_rate import AzureVoiceUpdateParamsRate
 from .azure_voice_update_params_voice_name import AzureVoiceUpdateParamsVoiceName
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class AzureVoiceUpdateParams(pydantic.BaseModel):

--- a/src/vocode/types/dtmf_action_params.py
+++ b/src/vocode/types/dtmf_action_params.py
@@ -3,12 +3,15 @@
 import datetime as dt
 import typing
 
-import pydantic
-
 import typing_extensions
 
 from ..core.datetime_utils import serialize_datetime
 from .empty_action_config import EmptyActionConfig
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class DtmfActionParams(pydantic.BaseModel):

--- a/src/vocode/types/dtmf_action_update_params.py
+++ b/src/vocode/types/dtmf_action_update_params.py
@@ -4,10 +4,13 @@ import datetime as dt
 import typing
 import typing_extensions
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
 from .dtmf_action_update_params_config import DtmfActionUpdateParamsConfig
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class DtmfActionUpdateParams(pydantic.BaseModel):

--- a/src/vocode/types/eleven_labs_voice_params.py
+++ b/src/vocode/types/eleven_labs_voice_params.py
@@ -4,9 +4,12 @@ import datetime as dt
 import typing
 import typing_extensions
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class ElevenLabsVoiceParams(pydantic.BaseModel):

--- a/src/vocode/types/eleven_labs_voice_update_params.py
+++ b/src/vocode/types/eleven_labs_voice_update_params.py
@@ -3,8 +3,6 @@
 import datetime as dt
 import typing
 
-import pydantic
-
 import typing_extensions
 
 from ..core.datetime_utils import serialize_datetime
@@ -12,6 +10,11 @@ from .eleven_labs_voice_update_params_api_key import ElevenLabsVoiceUpdateParams
 from .eleven_labs_voice_update_params_similarity_boost import ElevenLabsVoiceUpdateParamsSimilarityBoost
 from .eleven_labs_voice_update_params_stability import ElevenLabsVoiceUpdateParamsStability
 from .eleven_labs_voice_update_params_voice_id import ElevenLabsVoiceUpdateParamsVoiceId
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class ElevenLabsVoiceUpdateParams(pydantic.BaseModel):

--- a/src/vocode/types/end_conversation_action_params.py
+++ b/src/vocode/types/end_conversation_action_params.py
@@ -3,12 +3,15 @@
 import datetime as dt
 import typing
 
-import pydantic
-
 import typing_extensions
 
 from ..core.datetime_utils import serialize_datetime
 from .empty_action_config import EmptyActionConfig
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class EndConversationActionParams(pydantic.BaseModel):

--- a/src/vocode/types/end_conversation_action_update_params.py
+++ b/src/vocode/types/end_conversation_action_update_params.py
@@ -4,10 +4,13 @@ import datetime as dt
 import typing
 import typing_extensions
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
 from .end_conversation_action_update_params_config import EndConversationActionUpdateParamsConfig
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class EndConversationActionUpdateParams(pydantic.BaseModel):

--- a/src/vocode/types/play_ht_voice_params.py
+++ b/src/vocode/types/play_ht_voice_params.py
@@ -4,9 +4,12 @@ import datetime as dt
 import typing
 import typing_extensions
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class PlayHtVoiceParams(pydantic.BaseModel):

--- a/src/vocode/types/play_ht_voice_update_params.py
+++ b/src/vocode/types/play_ht_voice_update_params.py
@@ -3,14 +3,17 @@
 import datetime as dt
 import typing
 
-import pydantic
-
 import typing_extensions
 
 from ..core.datetime_utils import serialize_datetime
 from .play_ht_voice_update_params_api_key import PlayHtVoiceUpdateParamsApiKey
 from .play_ht_voice_update_params_api_user_id import PlayHtVoiceUpdateParamsApiUserId
 from .play_ht_voice_update_params_voice_id import PlayHtVoiceUpdateParamsVoiceId
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class PlayHtVoiceUpdateParams(pydantic.BaseModel):

--- a/src/vocode/types/rime_voice_params.py
+++ b/src/vocode/types/rime_voice_params.py
@@ -4,9 +4,12 @@ import datetime as dt
 import typing
 import typing_extensions
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class RimeVoiceParams(pydantic.BaseModel):

--- a/src/vocode/types/rime_voice_update_params.py
+++ b/src/vocode/types/rime_voice_update_params.py
@@ -3,12 +3,15 @@
 import datetime as dt
 import typing
 
-import pydantic
-
 import typing_extensions
 
 from ..core.datetime_utils import serialize_datetime
 from .rime_voice_update_params_speaker import RimeVoiceUpdateParamsSpeaker
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class RimeVoiceUpdateParams(pydantic.BaseModel):

--- a/src/vocode/types/set_hold_action_params.py
+++ b/src/vocode/types/set_hold_action_params.py
@@ -4,11 +4,14 @@ import datetime as dt
 import typing
 import typing_extensions
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
 from .empty_action_config import EmptyActionConfig
 from .set_hold_action_params_action_trigger import SetHoldActionParamsActionTrigger
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class SetHoldActionParams(pydantic.BaseModel):

--- a/src/vocode/types/set_hold_action_update_params.py
+++ b/src/vocode/types/set_hold_action_update_params.py
@@ -4,11 +4,14 @@ import datetime as dt
 import typing
 import typing_extensions
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
 from .set_hold_action_update_params_action_trigger import SetHoldActionUpdateParamsActionTrigger
 from .set_hold_action_update_params_config import SetHoldActionUpdateParamsConfig
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class SetHoldActionUpdateParams(pydantic.BaseModel):

--- a/src/vocode/types/transfer_call_action_params.py
+++ b/src/vocode/types/transfer_call_action_params.py
@@ -3,12 +3,15 @@
 import datetime as dt
 import typing
 
-import pydantic
-
 import typing_extensions
 
 from ..core.datetime_utils import serialize_datetime
 from .transfer_call_config import TransferCallConfig
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class TransferCallActionParams(pydantic.BaseModel):

--- a/src/vocode/types/transfer_call_action_update_params.py
+++ b/src/vocode/types/transfer_call_action_update_params.py
@@ -4,10 +4,13 @@ import datetime as dt
 import typing
 import typing_extensions
 
-import pydantic
-
 from ..core.datetime_utils import serialize_datetime
 from .transfer_call_action_update_params_config import TransferCallActionUpdateParamsConfig
+
+try:
+    import pydantic.v1 as pydantic  # type: ignore
+except ImportError:
+    import pydantic  # type: ignore
 
 
 class TransferCallActionUpdateParams(pydantic.BaseModel):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
-import pytest
+from vocode.client import Vocode
 
-# Get started with writing tests with pytest at https://docs.pytest.org
-@pytest.mark.skip(reason="Unimplemented")
-def test_client() -> None:
-    assert True == True
+
+# Test client instantiation
+def test_client_instantiation() -> None:
+    Vocode(token="....")


### PR DESCRIPTION
In this PR: 
- We setup a test in `test_client.py` that tests client instantiation
- All `.fernignored` classes are made both Pydantic v1 and v2 compatible (similar to the non fernignored classes)